### PR TITLE
Update packages to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     },
     "bugs": "https://github.com/cablelabs/mpegtssections-js/issues",
     "devDependencies": {
-        "gluejs": "2.3.x",
-        "jshint": "2.5.x",
-        "nodeunit": "0.8.x"
+        "gluejs": "2.4.x",
+        "jshint": "2.9.x",
+        "nodeunit": "0.9.x"
     },
     "homepage": "https://github.com/cablelabs/mpegtssections-js",
     "license": "BSD-2-Clause",


### PR DESCRIPTION
This fixes 'registry returned 404 for GET on https://registry.npmjs.org/esprima-six' since esprima-six is a dependency of gluejs but was removed from npm in favor of esprima 2.0.
